### PR TITLE
Replaced all instances of 'Express Template'

### DIFF
--- a/app/controllers/root.js
+++ b/app/controllers/root.js
@@ -6,7 +6,7 @@ const controller = require('lib/wiring/controller')
 const root = (req, res) => {
   res.json({
     index: {
-      title: 'Express Template',
+      title: 'Raindrop Api',
       environment: req.app.get('env')
     }
   })


### PR DESCRIPTION
- Replaced title in root.js file from 'Express Template' to
'Raindrop Api'
- Server landing page looked like the following: 
```
{
"index": {
"title": "Express Template",
"environment": "production"
}
}
```
- Now the server landing page will look like the following:
```
{
"index": {
"title": "Raindrop Api",
"environment": "development"
}
}
```