### PR TITLE
Sign up bug fix

### DIFF
--- a/app/controllers/users.js
+++ b/app/controllers/users.js
@@ -46,10 +46,17 @@ const makeErrorHandler = (res, next) =>
 
 const signup = (req, res, next) => {
   const credentials = req.body.credentials
-  const user = { email: credentials.email, password: credentials.password }
+  const user = { email: credentials.email, password: credentials.password, confirmPassword: credentials.password_confirmation }
   getToken()
     .then(token => {
       user.token = token
+      return user
+    })
+    .then((user) => {
+      if (user.password !== user.confirmPassword) {
+        console.log('inside if statement and user is ', user)
+        return Promise.reject(new HttpError(400))
+      }
     })
     .then(() =>
       new User(user).save())


### PR DESCRIPTION
Initial problem:
      - A bug that allows users to successfully sign up regardless of
      whether or not the password and confirm password fields matched
Solution:
      - Add code that modified the signUp function
      - Add if statement that checks both password and confirm password
      fields match


   

