### PR TITLE
Set Carts to only be CRUDable by owning user

### DIFF
--- a/app/controllers/carts.js
+++ b/app/controllers/carts.js
@@ -81,8 +81,7 @@ module.exports = controller({
   update,
   destroy
 }, { before: [
-  { method: setUser, only: ['index', 'show'] },
-  { method: authenticate, except: ['index', 'show'] },
+  { method: authenticate },
   { method: setModel(Cart), only: ['show'] },
-  { method: setModel(Cart, { forUser: true }), only: ['update', 'destroy'] }
+  { method: setModel(Cart, { forUser: true }), only: ['update', 'destroy', 'index', 'show'] }
 ] })


### PR DESCRIPTION
Before, any user could view all existing carts, but only update/destroy
the carts they own. Now a user can only view their own carts.

Andrew, Ian